### PR TITLE
refactor taylor_expansion module

### DIFF
--- a/dictos/taylor_expansion.py
+++ b/dictos/taylor_expansion.py
@@ -43,18 +43,17 @@ def taylor_series(around, up_to):
     # set the function symbol.
     # For a futere enhancement (specifying function symbol by users).
 
-    deriv_orders = range(1, up_to + 1)  # +1 is correction for exclusive stop
-    # list of order of derivative [1, 2, 3, ..., up_to]
+    deriv_orders = range(up_to + 1)  # +1 is correction for exclusive stop
+    # list of order of derivative [0, 1, 2, 3, ..., up_to]
 
     df_set = [derivative_symbol(func, i) for i in deriv_orders]
-    # derivatives of function f [f^(1), f^(2), f^(3), ..., f^(up_to)]
+    # derivatives of function f [f, f^(1), f^(2), f^(3), ..., f^(up_to)]
 
     h = around
     coef = [h ** i * sp.Rational(1, sp.factorial(i)) for i in deriv_orders]
-    # coefficient each term [h, h**2/2, h**3/6, ..., h**up_to/up_to!]
+    # coefficient each term [1, h, h**2/2, h**3/6, ..., h**up_to/up_to!]
 
-    f = sp.symbols(func)
-    series = f + sum([df_set[i] * coef[i] for i in range(len(df_set))])
+    series = sum([df_set[i] * coef[i] for i in range(len(df_set))])
     # calculate summation of each term
 
     return series

--- a/dictos/taylor_expansion.py
+++ b/dictos/taylor_expansion.py
@@ -89,5 +89,8 @@ def derivative_symbol(function, deriv):
         # raise error if
         # - unsupproted order of derivative (< 0).
 
-    return sp.symbols(function + "^(%d)" % deriv)
-    # TODO: #33 return `"f"` not `"f^(0)"` when deriv is 0
+    return (
+        sp.symbols(function) if deriv == 0 else sp.symbols(function + "^(%d)" % deriv)
+    )
+    # when deriv == 0, return `"f"` not `"f^(0)"`
+    # when deriv >  0, return `"f^(deriv)"`


### PR DESCRIPTION
- return `f` not `f^(0)` when deriv == 0.
- include the first term in lists.

closes #33