### PR TITLE
fix unordered results

### DIFF
--- a/dictos/utils.py
+++ b/dictos/utils.py
@@ -41,7 +41,10 @@ def create_coordinate_symbols(stencil, interval=DEFAULT_INTERVAL):
         raise DuplicatedPointError(stencil)
         # raise error if
         # - at least a number in the stencil appears more than once.
-    # TODO: #4 sorting the stencil
+
+    stencil.sort()
+    # sorting the stencil to obtain an equation
+    # in which terms are arranged in the order of the stencil.
 
     return [stencil[i] * sp.symbols(interval) for i in range(len(stencil))]
 
@@ -190,7 +193,9 @@ def dot_product(numer, f_set, evaluate=False):
     step_ = -1
     eq = sp.Mul(numer[begin_], f_set[begin_], evaluate=evaluate)
     for i in range(begin_ + step_, end_, step_):
-        eq = sp.Add(eq, sp.Mul(numer[i], f_set[i], evaluate=evaluate), evaluate=evaluate)
+        eq = sp.Add(
+            eq, sp.Mul(numer[i], f_set[i], evaluate=evaluate), evaluate=evaluate
+        )
     # there is no way to accumulate a list of sympy symbols
     # without evalulation.
     # So for-loop and sympy.Add and .Mul are used.

--- a/dictos/utils.py
+++ b/dictos/utils.py
@@ -42,11 +42,13 @@ def create_coordinate_symbols(stencil, interval=DEFAULT_INTERVAL):
         # raise error if
         # - at least a number in the stencil appears more than once.
 
-    stencil.sort()
+    sorted_stencil = stencil[:]
+    sorted_stencil.sort()
     # sorting the stencil to obtain an equation
     # in which terms are arranged in the order of the stencil.
+    # a local variable is used to not change the passed stencil.
 
-    return [stencil[i] * sp.symbols(interval) for i in range(len(stencil))]
+    return [sorted_stencil[i] * sp.symbols(interval) for i in range(len(stencil))]
 
 
 def create_function_symbols(

--- a/test/test_finite_difference.py
+++ b/test/test_finite_difference.py
@@ -6,6 +6,7 @@ sys.path.insert(1, "..")
 
 import unittest
 import sympy as sp
+import random
 
 from dictos.finite_difference import equation, coefficients, truncation_error
 
@@ -59,13 +60,17 @@ class FiniteDifferenceTest(unittest.TestCase):
             )
             / (2520 * h),
         ]
-        for half_width in range(1, 6):
-            with self.subTest(
-                "%d-point central difference for 1st derivative" % (half_width * 2 + 1)
-            ):
-                stencil = [i for i in range(-half_width, half_width + 1)]
-                actual = equation(stencil, 1)
-                self.assertEqual(expected[half_width], actual)
+        for shuffle in [False, True]:
+            for half_width in range(1, 6):
+                with self.subTest(
+                    "%d-point central difference for 1st derivative, stencil shuffle = %r"
+                    % (half_width * 2 + 1, shuffle)
+                ):
+                    stencil = [i for i in range(-half_width, half_width + 1)]
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = equation(stencil, 1)
+                    self.assertEqual(expected[half_width], actual)
 
         expected = [
             0,
@@ -108,13 +113,17 @@ class FiniteDifferenceTest(unittest.TestCase):
             )
             / (25200 * h ** 2),
         ]
-        for half_width in range(1, 6):
-            with self.subTest(
-                "%d-point central difference for 2nd derivative" % (half_width * 2 + 1)
-            ):
-                stencil = [i for i in range(-half_width, half_width + 1)]
-                actual = equation(stencil, 2)
-                self.assertEqual(expected[half_width], actual)
+        for shuffle in [False, True]:
+            for half_width in range(1, 6):
+                with self.subTest(
+                    "%d-point central difference for 2nd derivative, stencil shuffle = %r"
+                    % (half_width * 2 + 1, shuffle),
+                ):
+                    stencil = [i for i in range(-half_width, half_width + 1)]
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = equation(stencil, 2)
+                    self.assertEqual(expected[half_width], actual)
 
         expected = [
             0,
@@ -185,13 +194,16 @@ class FiniteDifferenceTest(unittest.TestCase):
             )
             / (2520 * h),
         ]
-        for width in range(1, 11):
-            with self.subTest(
-                "%d-point forward difference for 1st derivative" % (width + 1)
-            ):
-                stencil = [i for i in range(width + 1)]
-                actual = equation(stencil, 1)
-                self.assertEqual(expected[width], actual)
+        for shuffle in [False, True]:
+            for width in range(1, 11):
+                with self.subTest(
+                    "%d-point forward difference for 1st derivative, stencil shuffle = %r"
+                    % (width + 1, shuffle)
+                ):
+                    stencil = [i for i in range(width + 1)]
+                    random.shuffle(stencil)
+                    actual = equation(stencil, 1)
+                    self.assertEqual(expected[width], actual)
 
     def test_coefficients(self):
         """
@@ -252,6 +264,16 @@ class FiniteDifferenceTest(unittest.TestCase):
                 actual = coefficients(stencil, 1)
                 self.assertEqual(expected[half_width], actual)
 
+        for half_width in range(1, 6):
+            with self.subTest(
+                "coefficents of %d-point central difference for 1st derivative"
+                % (half_width * 2 + 1)
+            ):
+                stencil = [i for i in range(-half_width, half_width + 1)]
+                random.shuffle(stencil)
+                actual = coefficients(stencil, 1)
+                self.assertEqual(expected[half_width], actual)
+
         expected = [
             0,
             ([-1, 0, 1], 2),
@@ -266,6 +288,16 @@ class FiniteDifferenceTest(unittest.TestCase):
                 % (half_width * 2 + 1)
             ):
                 stencil = [i for i in range(-half_width, half_width + 1)]
+                actual = coefficients(stencil, 1, as_numer_denom=True)
+                self.assertEqual(expected[half_width], actual)
+
+        for half_width in range(1, 6):
+            with self.subTest(
+                "numerator and denominator of coefficients of %d-point central difference for 1st derivative"
+                % (half_width * 2 + 1)
+            ):
+                stencil = [i for i in range(-half_width, half_width + 1)]
+                random.shuffle(stencil)
                 actual = coefficients(stencil, 1, as_numer_denom=True)
                 self.assertEqual(expected[half_width], actual)
 

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -6,6 +6,7 @@ sys.path.insert(1, "..")
 
 import unittest
 import sympy as sp
+import random
 
 from dictos.interpolation import equation, coefficients, truncation_error
 
@@ -57,12 +58,18 @@ class InterpolationTest(unittest.TestCase):
             - 5 * f_8 / 126
             + f_9 / 252,
         ]
-        for half_width in range(1, 6):
-            with self.subTest("%d-point central interpolation" % (half_width * 2)):
-                stencil = [i for i in range(-half_width, half_width + 1)]
-                stencil.remove(0)
-                actual = equation(stencil)
-                self.assertEqual(expected[half_width], actual)
+        for shuffle in [False, True]:
+            for half_width in range(1, 6):
+                with self.subTest(
+                    "%d-point central interpolation, stencil shuffle = %r"
+                    % (half_width * 2, shuffle)
+                ):
+                    stencil = [i for i in range(-half_width, half_width + 1)]
+                    stencil.remove(0)
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = equation(stencil)
+                    self.assertEqual(expected[half_width], actual)
 
         expected = [
             0,
@@ -91,11 +98,17 @@ class InterpolationTest(unittest.TestCase):
             - 9 * f_7
             + f_8,
         ]
-        for width in range(2, 10):
-            with self.subTest("%d-point extrapolation" % (width * 2)):
-                stencil = [i for i in range(1, width + 1)]
-                actual = equation(stencil)
-                self.assertEqual(expected[width], actual)
+        for shuffle in [False, True]:
+            for width in range(2, 10):
+                with self.subTest(
+                    "%d-point extrapolation, stencil shuffle = %r"
+                    % (width * 2, shuffle)
+                ):
+                    stencil = [i for i in range(1, width + 1)]
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = equation(stencil)
+                    self.assertEqual(expected[width], actual)
 
     def test_coefficients(self):
         """
@@ -142,13 +155,17 @@ class InterpolationTest(unittest.TestCase):
                 sp.Rational(1, 252),
             ],
         ]
-        for half_width in range(1, 6):
-            with self.subTest(
-                "coefficients of %d-point central interpolation" % (half_width * 2)
-            ):
-                stencil = [i for i in range(-half_width, half_width + 1)]
-                stencil.remove(0)
-                actual = coefficients(stencil)
+        for shuffle in [False, True]:
+            for half_width in range(1, 6):
+                with self.subTest(
+                    "coefficients of %d-point central interpolation, stencil shuffle = %r"
+                    % (half_width * 2, shuffle)
+                ):
+                    stencil = [i for i in range(-half_width, half_width + 1)]
+                    stencil.remove(0)
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = coefficients(stencil)
                 self.assertEqual(expected[half_width], actual)
 
         expected = [
@@ -181,11 +198,17 @@ class InterpolationTest(unittest.TestCase):
             [8, -28, 56, -70, 56, -28, 8, -1],
             [9, -36, 84, -126, 126, -84, 36, -9, 1],
         ]
-        for width in range(2, 10):
-            with self.subTest("coefficients of %d-point extrapolation" % width):
-                stencil = [i for i in range(1, width + 1)]
-                actual = coefficients(stencil)
-                self.assertEqual(expected[width], actual)
+        for shuffle in [False, True]:
+            for width in range(2, 10):
+                with self.subTest(
+                    "coefficients of %d-point extrapolation, stencil shuffle = %r"
+                    % (width, shuffle)
+                ):
+                    stencil = [i for i in range(1, width + 1)]
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = coefficients(stencil)
+                    self.assertEqual(expected[width], actual)
 
         expected = [
             0,
@@ -199,14 +222,17 @@ class InterpolationTest(unittest.TestCase):
             ([8, -28, 56, -70, 56, -28, 8, -1], 1),
             ([9, -36, 84, -126, 126, -84, 36, -9, 1], 1),
         ]
-        for width in range(2, 10):
-            with self.subTest(
-                "coefficients as numerator and denominator of %d-point extrapolation"
-                % width
-            ):
-                stencil = [i for i in range(1, width + 1)]
-                actual = coefficients(stencil, as_numer_denom=True)
-                self.assertEqual(expected[width], actual)
+        for shuffle in [False, True]:
+            for width in range(2, 10):
+                with self.subTest(
+                    "coefficients as numerator and denominator of %d-point extrapolation, stencil shuffle = %r"
+                    % (width, shuffle)
+                ):
+                    stencil = [i for i in range(1, width + 1)]
+                    if shuffle:
+                        random.shuffle(stencil)
+                    actual = coefficients(stencil, as_numer_denom=True)
+                    self.assertEqual(expected[width], actual)
 
     def test_truncation_error(self):
         """


### PR DESCRIPTION
Fix a bug that returns an equation in which terms are not arranged.
The original stencil is not sorted.

```python
stencil = [-1, 0, 1, -2, 2]
print(fd.equation(stencil, deriv=1, same_subscripts_as_stencil=True, evaluate=False))
# (f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2})/(12*h)
print(stencil)
# [-1, 0, 1, -2, 2]
```
closes #43 
closes #4 