### PR TITLE
add and remove type hints

### DIFF
--- a/dictos/error/lagrangian_polynomial.py
+++ b/dictos/error/lagrangian_polynomial.py
@@ -23,7 +23,7 @@ class InconsistentDataSetError(LagrangianPolynomialError):
         message (str): Explanation of the error.
     """
 
-    def __init__(self, x_set: list, f_set: list) -> None:
+    def __init__(self, x_set, f_set) -> None:
         self.x_set = x_set
         self.f_set = f_set
         self.message = (
@@ -47,7 +47,7 @@ class DegreeOfPolynomialIsNotNaturalNumberError(LagrangianPolynomialError):
         message (str): Explanation of the error.
     """
 
-    def __init__(self, degree: int) -> None:
+    def __init__(self, degree) -> None:
         self.degree = degree
         self.message = (
             "The degree of polynomial ({}) is not the natural number. ".format(degree)

--- a/dictos/error/stencil.py
+++ b/dictos/error/stencil.py
@@ -18,7 +18,7 @@ class TooNarrowError(StencilError):
     Exception raised for errors that the stencil is too narrow.
     """
 
-    def __init__(self, stencil: list) -> None:
+    def __init__(self, stencil) -> None:
         self.message = (
             "The stencil width {} is too narrow. ".format(len(stencil))
             + "Use a stencil containing at least 2 points."
@@ -39,7 +39,7 @@ class DuplicatedPointError(StencilError):
         message (str): Explanation of the error.
     """
 
-    def __init__(self, stencil: list) -> None:
+    def __init__(self, stencil) -> None:
         self.stencil = stencil
         self.message = (
             "The stencil has at least one duplicated point. "

--- a/dictos/finite_difference.py
+++ b/dictos/finite_difference.py
@@ -17,11 +17,11 @@ from .error.finite_difference import UnsupportedOrderOfDerivativeError
 
 
 def equation(
-    stencil,
-    deriv=1,
-    interval=DEFAULT_INTERVAL,
-    same_subscripts_as_stencil=False,
-    evaluate=True,
+    stencil: list,
+    deriv: int = 1,
+    interval: str = DEFAULT_INTERVAL,
+    same_subscripts_as_stencil: bool = False,
+    evaluate: bool = True,
 ):
     """
     derive finite difference equation based on given stencil.
@@ -91,7 +91,7 @@ def equation(
     return eq
 
 
-def coefficients(stencil, deriv=1, as_numer_denom=False):
+def coefficients(stencil: list, deriv: int = 1, as_numer_denom: bool = False):
     """
     derive finite difference coefficients based on given stencil.
 
@@ -149,7 +149,7 @@ def coefficients(stencil, deriv=1, as_numer_denom=False):
     # simplify floating-point number coefficients to ratioanl numbers
 
 
-def truncation_error(stencil, deriv, interval=DEFAULT_INTERVAL):
+def truncation_error(stencil: list, deriv: int, interval: str = DEFAULT_INTERVAL):
     """
     derive the leading-order of error term
     in the finite difference equation based on the given stencil.

--- a/dictos/interpolation.py
+++ b/dictos/interpolation.py
@@ -16,7 +16,7 @@ from .taylor_expansion import taylor_series
 from .error.stencil import ContainsZeroError
 
 
-def equation(stencil, same_subscripts_as_stencil=False):
+def equation(stencil: list, same_subscripts_as_stencil: bool = False):
     """
     derive interpolation equation based on given stencil.
     The equation compute interpolation at stencil = 0
@@ -56,7 +56,7 @@ def equation(stencil, same_subscripts_as_stencil=False):
     # calculate dot product of the coef and function values.
 
 
-def coefficients(stencil, as_numer_denom=False):
+def coefficients(stencil: list, as_numer_denom: bool = False):
     """
     derive interpolation coefficients based on given stencil.
 
@@ -114,7 +114,7 @@ def coefficients(stencil, as_numer_denom=False):
     # simplify floating-point number coefficients to ratioanl numbers
 
 
-def truncation_error(stencil, interval=DEFAULT_INTERVAL):
+def truncation_error(stencil: list, interval: str = DEFAULT_INTERVAL):
     """
     derive the leading-order of error term
     in the interpolation equation based on the given stencil

--- a/dictos/lagrangian_polynomial.py
+++ b/dictos/lagrangian_polynomial.py
@@ -87,7 +87,8 @@ def lagrangian_poly(x, x_set, f_set):
     from ginve set of coordinates and functions.
 
     Args:
-        x (sympy symbol): symbol representing independent variable.
+        x (sympy symbol):
+            symbol representing independent variable.
         x_set (list or tuple of sympy symbols):
             set of coordinate values.
         f_set (list or tuple of sympy symbols):

--- a/dictos/lagrangian_polynomial.py
+++ b/dictos/lagrangian_polynomial.py
@@ -15,7 +15,7 @@ from .spec import (
 )
 
 
-def lagrangian_basis(x, degree, point_at, x_set=None):
+def lagrangian_basis(x, degree: int, point_at: int, x_set: list = None):
     """
     create Lagrangian basis from give coordinate symbols.
 
@@ -131,7 +131,7 @@ def lagrangian_poly(x, x_set, f_set):
     # at coordinates and the Lagrangian basis polynomials.
 
 
-def derivative(expr, x, deriv=1):
+def derivative(expr, x, deriv: int = 1):
     """calculate symbolically a derivative at x=0.
 
     Args:

--- a/dictos/linalg.py
+++ b/dictos/linalg.py
@@ -6,7 +6,7 @@ from .spec import (
 from .error.linear_algebra import InconsistentDataSetError
 
 
-def dot_product(vec1, vec2, evaluate=True):
+def dot_product(vec1, vec2, evaluate: bool = True):
     """
     calculate dot product of two list
     containing sympy numbers and symbols without evaluation.

--- a/dictos/linalg.py
+++ b/dictos/linalg.py
@@ -1,8 +1,6 @@
 import sympy as sp
 
-from .spec import (
-    are_different_length,
-)
+from .spec import are_different_length
 from .error.linear_algebra import InconsistentDataSetError
 
 

--- a/dictos/spec.py
+++ b/dictos/spec.py
@@ -12,7 +12,7 @@ def narrower_than_minimum_width(data_set) -> bool:
     the minimum value specified in the spec.py.
 
     Args:
-        data_set (list): data set to be checked.
+        data_set (list or tuple): data set to be checked.
 
     Returns:
         bool: True if stencil used in data_set is narrower.
@@ -68,8 +68,8 @@ def are_different_length(list1, list2) -> bool:
     """Return True if length of two lists are different.
 
     Args:
-        list1 (list): a list to be checked.
-        list2 (list): a list to be checked.
+        list1 (list or tuple): a list to be checked.
+        list2 (list or tuple): a list to be checked.
 
     Returns:
         bool: True if length of two lists are different.
@@ -82,7 +82,7 @@ def is_not_assumed_length(list, assumed_length: int) -> bool:
     Return Ture if the list length is not the assumed length.
 
     Args:
-        list (list): a list to be checked.
+        list (list or tuple): a list to be checked.
         assumed_length (int): assumed length of the list.
 
     Returns:
@@ -112,8 +112,8 @@ def are_same_length(list1, list2) -> bool:
     """Return True if length of two lists are the same.
 
     Args:
-        list1 (list): a list to be checked.
-        list2 (list): a list to be checked.
+        list1 (list or tuple): a list to be checked.
+        list2 (list or tuple): a list to be checked.
 
     Returns:
         bool: True if length of two lists are the same.
@@ -126,7 +126,7 @@ def is_assumed_length(list, assumed_length: int) -> bool:
     Return Ture if the list length is the assumed length.
 
     Args:
-        list (list): a list to be checked.
+        list (list or tuple): a list to be checked.
         assumed_length (int): assumed length of the list.
 
     Returns:

--- a/dictos/spec.py
+++ b/dictos/spec.py
@@ -36,7 +36,7 @@ def is_not_natrual_number(number, include_zero: bool = False) -> bool:
     return not is_natural_number(number, include_zero)
 
 
-def has_zero(stencil: list) -> bool:
+def has_zero(stencil) -> bool:
     """
     Return True if the stencil has 0.
 
@@ -50,7 +50,7 @@ def has_zero(stencil: list) -> bool:
     return 0 in stencil
 
 
-def has_duplicated_points(stencil: list) -> bool:
+def has_duplicated_points(stencil) -> bool:
     """
     Returns True if there is at least one duplicated points in the stencil.
 
@@ -64,7 +64,7 @@ def has_duplicated_points(stencil: list) -> bool:
     return len(stencil) != len(set(stencil))
 
 
-def are_different_length(list1: list, list2: list) -> bool:
+def are_different_length(list1, list2) -> bool:
     """Return True if length of two lists are different.
 
     Args:
@@ -77,7 +77,7 @@ def are_different_length(list1: list, list2: list) -> bool:
     return not are_same_length(list1, list2)
 
 
-def is_not_assumed_length(list: list, assumed_length: int) -> bool:
+def is_not_assumed_length(list, assumed_length: int) -> bool:
     """
     Return Ture if the list length is not the assumed length.
 
@@ -108,7 +108,7 @@ def is_natural_number(number, include_zero: bool = False) -> bool:
     return isinstance(number, int) and number >= lower_bound
 
 
-def are_same_length(list1: list, list2: list) -> bool:
+def are_same_length(list1, list2) -> bool:
     """Return True if length of two lists are the same.
 
     Args:
@@ -121,7 +121,7 @@ def are_same_length(list1: list, list2: list) -> bool:
     return len(list1) == len(list2)
 
 
-def is_assumed_length(list: list, assumed_length: int) -> bool:
+def is_assumed_length(list, assumed_length: int) -> bool:
     """
     Return Ture if the list length is the assumed length.
 

--- a/dictos/taylor_expansion.py
+++ b/dictos/taylor_expansion.py
@@ -9,7 +9,7 @@ from .error.taylor_expansion import (
 )
 
 
-def taylor_series(around, up_to):
+def taylor_series(around, up_to: int):
     """
     calculate Taylor series of f(x) around h
 
@@ -66,7 +66,7 @@ def taylor_series(around, up_to):
     return series
 
 
-def derivative_symbol(function, deriv):
+def derivative_symbol(function: str, deriv: int):
     """
     returns n-th order derivative of function f as a sympy symbol
 

--- a/dictos/utils.py
+++ b/dictos/utils.py
@@ -13,7 +13,7 @@ DEFAULT_INTERVAL = "h"  # str for interval symbol
 DEFAULT_FUNCTION = "f"  # str for function symbol
 
 
-def create_coordinate_symbols(stencil, interval=DEFAULT_INTERVAL):
+def create_coordinate_symbols(stencil: list, interval: str = DEFAULT_INTERVAL) -> list:
     """
     create set of coordinate symbols from stencil.
     input a list of numbers like `[-1, 0, 1]` as stencil,
@@ -55,9 +55,9 @@ def create_coordinate_symbols(stencil, interval=DEFAULT_INTERVAL):
 
 
 def create_function_symbols(
-    x_set,
-    function=DEFAULT_FUNCTION,
-    same_subscripts_as_stencil=False,
+    x_set: list,
+    function: str = DEFAULT_FUNCTION,
+    same_subscripts_as_stencil: bool = False,
 ):
     """
     create set of function symbols at coordinates from x_set.
@@ -107,7 +107,7 @@ def create_function_symbols(
     return f_set
 
 
-def simplify_coefficients(coef, as_numer_denom=False):
+def simplify_coefficients(coef, as_numer_denom: bool = False):
     """
     simplify coefficients in floating-point number
     to ratioanl numbers.


### PR DESCRIPTION
- add some type hints for primitive variables including `int`, `bool`, `list`
- remove some type hints related to `list` and `tuple`

Python's type system is too complicated for me especially Collection etc., so simplify type hints.

closes #39 