### PR TITLE
replace retval type with custom class

### DIFF
--- a/dictos/finite_difference.py
+++ b/dictos/finite_difference.py
@@ -16,6 +16,7 @@ from .linalg import dot_product, div
 from .lagrangian_polynomial import lagrangian_poly, derivative
 from .taylor_expansion import taylor_series, derivative_symbol
 from .error.finite_difference import UnsupportedOrderOfDerivativeError
+from .core.expr import Expr
 
 
 def equation(
@@ -24,7 +25,7 @@ def equation(
     interval: str = DEFAULT_INTERVAL,
     sort: bool = True,
     keep_zero: bool = False,
-):
+) -> Expr:
     """
     derive finite difference equation based on given stencil.
 
@@ -39,7 +40,7 @@ def equation(
             Defaults to False.
 
     Returns:
-        sympy Expr: derived finite difference equation.
+        dictos Expr: derived finite difference equation.
 
     Examples:
         >>> from dictos import finite_difference as fd
@@ -83,7 +84,7 @@ def equation(
         eq = sort_by_subscript(eq)
     # sort numerator by subscript.
 
-    return eq
+    return Expr(eq)
 
 
 def coefficients(stencil: list, deriv: int = 1, as_numer_denom: bool = False):

--- a/dictos/interpolation.py
+++ b/dictos/interpolation.py
@@ -16,9 +16,10 @@ from .linalg import dot_product
 from .lagrangian_polynomial import lagrangian_poly
 from .taylor_expansion import taylor_series
 from .error.stencil import ContainsZeroError
+from .core.expr import Expr
 
 
-def equation(stencil: list, sort: bool = True):
+def equation(stencil: list, sort: bool = True) -> Expr:
     """
     derive interpolation equation based on given stencil.
     The equation compute interpolation at stencil = 0
@@ -54,7 +55,7 @@ def equation(stencil: list, sort: bool = True):
         eq = sort_by_subscript(eq)
     # sort numerator by subscript.
 
-    return eq
+    return Expr(eq)
 
 
 def coefficients(stencil: list, as_numer_denom: bool = False):

--- a/dictos/linalg.py
+++ b/dictos/linalg.py
@@ -30,26 +30,12 @@ def dot_product(vec1, vec2, evaluate: bool = True):
 
     if evaluate:
         eq = sum([vec1[i] * vec2[i] for i in range(len(vec1))])
-        # when evaluate = True, a result obtained using sp.Mul and sp.Add
-        # with evaluate=True is the same as it
-        # obtained using `*` operation and the sum function.
     else:
-        begin_ = len(vec2) - 1  # exclude first term
-        end_ = -1  # to generate numbers up to 0 using range()
-        step_ = -1
-        eq = sp.Mul(vec1[begin_], vec2[begin_], evaluate=evaluate)
-        for i in range(begin_ + step_, end_, step_):
-            eq = sp.Add(
-                eq, sp.Mul(vec1[i], vec2[i], evaluate=evaluate), evaluate=evaluate
-            )
+        terms = [sp.Mul(vec1[i], vec2[i], evaluate=False) for i in range(len(vec1))]
+        eq = sp.Add(*terms, evaluate=False)
         # there is no way to accumulate a list of sympy symbols
         # without evaluation.
         # So for-loop and sympy.Add and .Mul are used.
-        # The for-loop is downstepped
-        # so that the result are sorted when it is printed.
-        # The result of the accumulation, `((-a*f_{-1} +b*f_{0}) + a*f_{1})`,
-        # is printed as `a*f_{1} + b*f_{0} - a*f_{-1}`.
-        # downstepping is used for sorting.
 
     return eq
 

--- a/dictos/utils.py
+++ b/dictos/utils.py
@@ -237,21 +237,14 @@ def sort_by_subscript(expr):
     # rearrange numerator in order of the subscripts.
     if all([s < 0 for s in subscripts]):
         # if all subscripts are negative integer,
-        numer_sorted = numer_sorted_terms[0]
-        for n in numer_sorted_terms[1:]:
-            numer_sorted = sp.Add(numer_sorted, n, evaluate=False)
-        # (((3*f_{-1}) - 3*f_{-2}) + f_{-3})
-    elif all([s > 0 for s in subscripts]):
-        # if all subscripts are positive integer,
-        numer_sorted = numer_sorted_terms[-1]
-        for n in numer_sorted_terms[-2::-1]:
-            numer_sorted = sp.Add(numer_sorted, n, evaluate=False)
-        # (((3*f_{1}) - 3*f_{2}) + f_{3})
+        #
+        # 3*f_{-1} - 3*f_{-2} + f_{-3}
+        numer_sorted = sp.Add(*numer_sorted_terms[::-1], evaluate=False)
     else:
-        numer_sorted = numer_sorted_terms[-1]
-        for n in numer_sorted_terms[-2::-1]:
-            numer_sorted = sp.Add(numer_sorted, n, evaluate=False)
-        # ((((-f_{2} + 8*f_{1}) + 0*f_{0}) - 8*f_{-1}) + f_{-2})
+        # 3*f_{1} - 3*f_{2} + f_{3}
+        # f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2}
+        # etc.
+        numer_sorted = sp.Add(*numer_sorted_terms, evaluate=False)
 
     if type(denom) is sp.core.numbers.Integer:
         return sp.Mul(numer_sorted, sp.Rational(1, denom), evaluate=False)


### PR DESCRIPTION
- changed the retval type of `equation` in `finite_difference` and `interpolation` from `sympy.Expr` to `dictos.Expr` introduced the PR #102 
- removed processes to keep the order of terms without `dictos.Expr`
- closes #103 