### PR TITLE
fixed `finite_difference.equation` to remove coefficients of terms with coefficient of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fixed a typo (natrual to natural). #94
 - fixed sympy class references from full-path to alias. #104
 - fixed tests along with changes in directory structure. #107
+- fixed `finite_difference.equation` to remove the coefficient from terms with a coefficient of 1. #118
 
 ### Repository updates
 - fixed equations in README. #117
-- update examples in README along with the current behavior. #117
+- update examples in README along with the current behavior. #117, #118
 
 ## [0.4.0] - 2022-02-08
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ from dictos import finite_difference as fd
 
 stencil = [-2, -1, 0, 1, 2]
 print(fd.equation(stencil, deriv=1, keep_zero=True))
-# (1*f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2})/(12*h)
+# (f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2})/(12*h)
 ```
 
 Tom: "Well... can I extract the coefficients?"

--- a/dictos/calculus/finite_difference.py
+++ b/dictos/calculus/finite_difference.py
@@ -13,6 +13,7 @@ from dictos.discrete.stencil import (
 from dictos.utilities.utils import (
     simplify_coefficients,
     extract_coefficients_as_numer_denom,
+    drop_coefficient_of_1,
     sort_by_subscript,
 )
 from dictos.linalg.linalg import dot_product, div
@@ -73,7 +74,7 @@ def equation(
     else:
         numer, denom = coefficients(stencil, deriv, as_numer_denom=True)
         eq = div(
-            dot_product(numer, f_set, evaluate=False),
+            drop_coefficient_of_1(dot_product(numer, f_set, evaluate=False)),
             denom * sp.symbols(interval) ** deriv,
         )
         # get coefficients as numerator and denominator and then

--- a/dictos/calculus/finite_difference.py
+++ b/dictos/calculus/finite_difference.py
@@ -62,16 +62,7 @@ def equation(
 
     # derive finite difference coefficients based on given stencil,
     # and then calculate dot product of the coefs and differentiands.
-    if not keep_zero:
-        coef = coefficients(stencil, deriv)
-        eq = sp.simplify(dot_product(coef, f_set) / sp.symbols(interval) ** deriv)
-        # The result of dot product is divided by interval symbol,
-        # because `coef` does not contain interval symbol like `dx`.
-        # Terms multiplied by a coefficient 0 is eliminated from a result like
-        # (-8*f_{-1} + f_{-2} + 8*f_{1} - f_{2})/(12*h).
-        # `keep_zero=True` keep terms  multiplied by a coefficient 0,
-        # (f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2})/(12*h).
-    else:
+    if keep_zero:
         numer, denom = coefficients(stencil, deriv, as_numer_denom=True)
         eq = div(
             drop_coefficient_of_1(dot_product(numer, f_set, evaluate=False)),
@@ -83,6 +74,15 @@ def equation(
         # and avoid reducing the coefficients.
         # `div` calculates division with evaluation,
         # but the coefficients are not reduced.
+    else:
+        coef = coefficients(stencil, deriv)
+        eq = sp.simplify(dot_product(coef, f_set) / sp.symbols(interval) ** deriv)
+        # The result of dot product is divided by interval symbol,
+        # because `coef` does not contain interval symbol like `dx`.
+        # Terms multiplied by a coefficient 0 is eliminated from a result like
+        # (-8*f_{-1} + f_{-2} + 8*f_{1} - f_{2})/(12*h).
+        # `keep_zero=True` keep terms  multiplied by a coefficient 0,
+        # (f_{-2} - 8*f_{-1} + 0*f_{0} + 8*f_{1} - f_{2})/(12*h).
 
     if sort:
         eq = sort_by_subscript(eq)

--- a/dictos/utilities/utils.py
+++ b/dictos/utilities/utils.py
@@ -143,7 +143,7 @@ def decompose_addition(expr_add):
 
     if type(expr_add) is sp.Symbol or type(expr_add) is sp.Mul:
         return expr_add
-        # is type of `expr_add` is Symbol or Mul, there is nothing more to do.
+        # if type of `expr_add` is Symbol or Mul, there is nothing more to do.
 
     if type(expr_add) is not sp.Add:
         raise TypeError(expr_add, type(expr_add))

--- a/test/utilities/test_utils.py
+++ b/test/utilities/test_utils.py
@@ -18,6 +18,7 @@ from dictos.utilities.utils import (
     simplify_coefficients,
     extract_coefficients_as_numer_denom,
     sort_by_subscript,
+    drop_coefficient_of_1,
 )
 from dictos.linalg.linalg import dot_product
 from test.utilities.gen import (
@@ -255,6 +256,80 @@ class UtilsTest(unittest.TestCase):
                 ac_str = str(actual)
                 ex_str = str(expected)
                 self.assertEqual(ex_str, ac_str)
+
+    def test_utils_drop_coefficient_of_1(self):
+        """test suite for utils.drop_coefficient_of_1."""
+        x, y, z = sp.symbols("x, y, z")
+
+        with self.subTest("a term with coefficient of 1"):
+            eq = 1 * x
+
+            expected = x
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("a term with coefficient not equal to 1"):
+            eq = 2 * x
+
+            expected = 2 * x
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("a term without coefficient"):
+            eq = x
+
+            expected = x
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("a term with (unsupported) nested addition"):
+            eq = (1 * x + 2 * y) * z
+
+            expected = z
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("two terms with coefficient of 1"):
+            eq = 1 * x + 1 * y
+
+            expected = x + y
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("two terms with coefficient not equal to 1"):
+            eq = 2 * x + 3 * y
+
+            expected = 2 * x + 3 * y
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
+
+        with self.subTest("two terms without coefficient"):
+            eq = x + y
+
+            expected = x + y
+            actual = drop_coefficient_of_1(eq)
+
+            ac_str = str(actual)
+            ex_str = str(expected)
+            self.assertEqual(ex_str, ac_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- added `drop_coefficient_of_1` to remove coefficients in `sp.Add`.
- updated README along with the fixed behavior
- added tests for `drop_coefficient_of_1` and confirmed all tests are passed.
- closes #118 